### PR TITLE
Support SSH URL

### DIFF
--- a/src-clj/acha/util.clj
+++ b/src-clj/acha/util.clj
@@ -97,7 +97,8 @@
     normalize-uri
     (as-> url
       (if (or (.startsWith url "http://")
-              (.startsWith url "https://"))
+              (.startsWith url "https://")
+              (.startsWith url "git@"))
         (resolve-redirects url)
         url))))
 


### PR DESCRIPTION
Fix java.net.URISyntaxException: Illegal character in scheme name at index 3: git@hostname:foo/bar.git